### PR TITLE
Code review

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -4,13 +4,13 @@ namespace Spatie\Robots;
 
 class Robots
 {
-    /** @var null|string */
+    /** @var string|null */
     protected $userAgent;
 
-    /** @var null|\Spatie\Robots\RobotsTxt */
+    /** @var \Spatie\Robots\RobotsTxt|null */
     protected $robotsTxt;
 
-    public function __construct(?string $userAgent = null, ?string $source = null)
+    public function __construct(string $userAgent = null, string $source = null)
     {
         $this->userAgent = $userAgent;
 
@@ -26,18 +26,16 @@ class Robots
         return $this;
     }
 
-    public static function create(?string $userAgent = null, ?string $source = null): self
+    public static function create(string $userAgent = null, string $source = null): self
     {
         return new self($userAgent, $source);
     }
 
-    public function mayIndex(string $url, ?string $userAgent = null): bool
+    public function mayIndex(string $url, string $userAgent = null): bool
     {
         $userAgent = $userAgent ?? $this->userAgent;
 
-        $robotsTxt =
-            $this->robotsTxt
-            ?? RobotsTxt::create($this->createRobotsUrl($url));
+        $robotsTxt = $this->robotsTxt ?? RobotsTxt::create($this->createRobotsUrl($url));
 
         return
             $robotsTxt->allows($url, $userAgent)

--- a/tests/RobotsHeadersTest.php
+++ b/tests/RobotsHeadersTest.php
@@ -26,26 +26,22 @@ class RobotsHeadersTest extends TestCase
     /** @test */
     public function it_can_read_response_headers_from_a_server()
     {
-        try {
-            $robots = RobotsHeaders::readFrom($this->getLocalServerUrl('/nofollow'));
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
 
-            $this->assertTrue($robots->mayIndex());
-            $this->assertFalse($robots->mayFollow());
-        } catch (InvalidArgumentException $e) {
-            $this->markTestSkipped('Could not connect to the server.');
-        }
+        $robots = RobotsHeaders::readFrom($this->getLocalTestServerUrl('/nofollow'));
+
+        $this->assertTrue($robots->mayIndex());
+        $this->assertFalse($robots->mayFollow());
     }
 
     /** @test */
     public function it_can_read_response_headers_from_a_server_for_a_user_agent()
     {
-        try {
-            $robots = RobotsHeaders::readFrom($this->getLocalServerUrl('/nofollow-noindex-google'));
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
 
-            $this->assertFalse($robots->mayIndex('google'));
-            $this->assertFalse($robots->mayFollow('google'));
-        } catch (InvalidArgumentException $e) {
-            $this->markTestSkipped('Could not connect to the server.');
-        }
+        $robots = RobotsHeaders::readFrom($this->getLocalTestServerUrl('/nofollow-noindex-google'));
+
+        $this->assertFalse($robots->mayIndex('google'));
+        $this->assertFalse($robots->mayFollow('google'));
     }
 }

--- a/tests/RobotsMetaTest.php
+++ b/tests/RobotsMetaTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Spatie\Robots;
+namespace Spatie\Robots\Test;
 
 use PHPUnit\Framework\TestCase;
 use Spatie\Robots\RobotsMeta;

--- a/tests/RobotsMetaTest.php
+++ b/tests/RobotsMetaTest.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Spatie\Robots\Test;
+namespace Spatie\Robots\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Robots\RobotsMeta;
 
 class RobotsMetaTest extends TestCase

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -46,16 +46,14 @@ class RobotsTest extends TestCase
     /** @test */
     public function it_can_discover_default_robots_file()
     {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
         $robots = Robots::create();
 
-        try {
-            $this->assertFalse($robots->mayIndex($this->getLocalServerUrl('/nl/admin')));
+        $this->assertFalse($robots->mayIndex($this->getLocalTestServerUrl('/nl/admin')));
 
-            $this->assertFalse($robots->mayIndex($this->getLocalServerUrl('/nl/admin/')));
+        $this->assertFalse($robots->mayIndex($this->getLocalTestServerUrl('/nl/admin/')));
 
-            $this->assertTrue($robots->mayIndex($this->getLocalServerUrl('/nl')));
-        } catch (InvalidArgumentException $e) {
-            $this->markTestSkipped('Could not connect to the server.');
-        }
+        $this->assertTrue($robots->mayIndex($this->getLocalTestServerUrl('/nl')));
     }
 }

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Robots\Tests;
 
-use InvalidArgumentException;
 use Spatie\Robots\Robots;
 
 class RobotsTest extends TestCase

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Tests\Spatie\Robots;
+namespace Spatie\Robots\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Robots\RobotsTxt;
 
 class RobotsTxtTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
             return;
         }
 
-        $this->markTestSkipped("The test server is not running. Start in by running `tests/server/start_server.sh`.");
+        $this->markTestSkipped("The test server is not running. Start it by running `tests/server/start_server.sh`.");
     }
 
     protected function localTestServerIsRunning(): bool

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,10 +4,26 @@ namespace Spatie\Robots\Tests;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    protected function getLocalServerUrl(string $url): string
+    protected function getLocalTestServerUrl(string $url = ''): string
     {
         $url = ltrim($url, '/');
 
         return "http://localhost:4020/{$url}";
+    }
+
+    protected function markAsSkippedUnlessLocalTestServerIsRunning()
+    {
+        if ($this->localTestServerIsRunning()) {
+            return;
+        }
+
+        $this->markTestSkipped("The test server is not running. Start in by running `tests/server/start_server.sh`.");
+    }
+
+    protected function localTestServerIsRunning(): bool
+    {
+        $contents = @file_get_contents($this->getLocalTestServerUrl('robots.txt'));
+
+        return ! empty($contents);
     }
 }


### PR DESCRIPTION
- I tried to change generic names like `parse` and  `content` to something with meaningfull
- Static constructors that are often used are better placed before generic constructors, see you can find them more easily
- Some functions were split up to make them more readable
- Refactored some array processing to make it more readable
- Avoided having to use an exception in order to skip a test