### PR TITLE
Feature/fix parsing robotstxt urls with keywords

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -114,7 +114,7 @@ class RobotsTxt
 
     protected function parseDisallow(string $line): string
     {
-        return trim(preg_replace('~disallow: ?~', '', strtolower(($line))));
+        return trim(substr_replace(strtolower(trim($line)), '', 0, 8), ': ');
     }
 
     protected function concernsDirectory(string $path): bool

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -114,7 +114,7 @@ class RobotsTxt
 
     protected function parseDisallow(string $line): string
     {
-        return trim(str_replace('disallow', '', strtolower(trim($line))), ': ');
+        return trim(preg_replace('~disallow: ?~', '', strtolower(($line))));
     }
 
     protected function concernsDirectory(string $path): bool

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -31,6 +31,14 @@ class RobotsTxtTest extends TestCase
     }
 
     /** @test */
+    public function test_disallow_keyword_in_url_is_correctly_disallowed()
+    {
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertFalse($robots->allows('/es/admin-disallow/', '*'));
+    }
+
+    /** @test */
     public function test_disallowed_link_for_default_user_agent()
     {
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');

--- a/tests/data/robots.txt
+++ b/tests/data/robots.txt
@@ -4,7 +4,7 @@ User-agent: *
 
 Disallow: /nl/admin/
 Disallow: /en/admin/
-
+Disallow: /es/admin-disallow/
 User-agent: google
 
 Disallow: /


### PR DESCRIPTION
Disallowed urls containing disallow word get truncated because str_replace change every ocurrence.
