### PR TITLE
Fix null/false confusion

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -10,9 +10,9 @@ class RobotsTxt
 
     public static function readFrom(string $source): self
     {
-        $content = @file_get_contents($source) ?? '';
+        $content = @file_get_contents($source);
 
-        return new self($content);
+        return new self($content !== false ? $content : '');
     }
 
     public function __construct(string $content)


### PR DESCRIPTION
- `file_get_contents()` returns `false` on failure
- the `??` operator only handles null values

=> right now, when `file_get_contents()` fails, it is not converted to `''`, but `false` is passed to the constructor; this only works because `strict_types` is off, and the value is implicitly converted to `string` due to the type-hint.