### PR TITLE
Implement wildcard, end-of-string, query string

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -36,15 +36,17 @@ class RobotsTxt
     {
         $requestUri = '';
 
-        $url = parse_url($url);
+        $parts = parse_url($url);
 
-        if ($url !== false) {
-            if (isset($url['path'])) {
-                $requestUri .= $url['path'];
+        if ($parts !== false) {
+            if (isset($parts['path'])) {
+                $requestUri .= $parts['path'];
             }
 
-            if (isset($url['query'])) {
-                $requestUri .= '?' . $url['query'];
+            if (isset($parts['query'])) {
+                $requestUri .= '?' . $parts['query'];
+            } elseif ($this->hasEmptyQueryString($url)) {
+                $requestUri .= '?';
             }
         }
 
@@ -88,6 +90,29 @@ class RobotsTxt
             if (preg_match($disallowRegexp, $requestUri) === 1) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks for an empty query string.
+     *
+     * This works around the fact that parse_url() will not set the 'query' key when the query string is empty.
+     * See: https://bugs.php.net/bug.php?id=78385
+     */
+    protected function hasEmptyQueryString(string $url) : bool
+    {
+        if ($url === '') {
+            return false;
+        }
+
+        if ($url[-1] === '?') { // ends with ?
+            return true;
+        }
+
+        if (strpos($url, '?#') !== false) { // empty query string, followed by a fragment
+            return true;
         }
 
         return false;

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -44,7 +44,7 @@ class RobotsTxt
             }
 
             if (isset($parts['query'])) {
-                $requestUri .= '?' . $parts['query'];
+                $requestUri .= '?'.$parts['query'];
             } elseif ($this->hasEmptyQueryString($url)) {
                 $requestUri .= '?';
             }
@@ -74,7 +74,7 @@ class RobotsTxt
             $disallowRegexp = preg_quote($disallow, '/');
 
             // the pattern must start at the beginning of the string...
-            $disallowRegexp = '^' . $disallowRegexp;
+            $disallowRegexp = '^'.$disallowRegexp;
 
             // ...and optionally stop at the end of the string
             if ($stopAtEndOfString) {
@@ -85,7 +85,7 @@ class RobotsTxt
             $disallowRegexp = str_replace('\\*', '.*', $disallowRegexp);
 
             // enclose in delimiters
-            $disallowRegexp = '/' . $disallowRegexp . '/';
+            $disallowRegexp = '/'.$disallowRegexp.'/';
 
             if (preg_match($disallowRegexp, $requestUri) === 1) {
                 return true;

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -55,7 +55,7 @@ class RobotsTest extends TestCase
 
         $robots = Robots::create();
 
-        $this->assertFalse($robots->mayIndex($this->getLocalTestServerUrl('/nl/admin')));
+        $this->assertTrue($robots->mayIndex($this->getLocalTestServerUrl('/nl/admin')));
 
         $this->assertFalse($robots->mayIndex($this->getLocalTestServerUrl('/nl/admin/')));
 

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -79,7 +79,7 @@ class RobotsTxtTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_stars_in_pattern()
+    public function it_can_handle_star_in_pattern()
     {
         $this->markAsSkippedUnlessLocalTestServerIsRunning();
 
@@ -91,6 +91,19 @@ class RobotsTxtTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_dollar_in_pattern()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertTrue($robots->allows('/fr/ad'));
+        $this->assertFalse($robots->allows('/fr/admin'));
+        $this->assertTrue($robots->allows('/fr/admin/'));
+        $this->assertTrue($robots->allows('/fr/admin?test'));
+    }
+
+    /** @test */
     public function it_can_handle_query_strings()
     {
         $this->markAsSkippedUnlessLocalTestServerIsRunning();
@@ -98,7 +111,8 @@ class RobotsTxtTest extends TestCase
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertTrue($robots->allows('/en/admin'));
-        $this->assertFalse($robots->allows('/en/admin?a'));
-        $this->assertFalse($robots->allows('/en/admin?a=b'));
+        $this->assertTrue($robots->allows('/en/admin?id=123'));
+        $this->assertFalse($robots->allows('/en/admin?print'));
+        $this->assertFalse($robots->allows('/en/admin?print=true'));
     }
 }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -77,4 +77,28 @@ class RobotsTxtTest extends TestCase
 
         $this->assertTrue($robots->allows('/'));
     }
+
+    /** @test */
+    public function it_can_handle_stars_in_pattern()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertTrue($robots->allows('/en/admin'));
+        $this->assertFalse($robots->allows('/en/admin/'));
+        $this->assertFalse($robots->allows('/en/admin/users'));
+    }
+
+    /** @test */
+    public function it_can_handle_query_strings()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertTrue($robots->allows('/en/admin'));
+        $this->assertFalse($robots->allows('/en/admin?a'));
+        $this->assertFalse($robots->allows('/en/admin?a=b'));
+    }
 }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -96,6 +96,7 @@ class RobotsTxtTest extends TestCase
         $this->assertTrue($robots->allows('/fr/ad'));
         $this->assertFalse($robots->allows('/fr/admin'));
         $this->assertTrue($robots->allows('/fr/admin/'));
+        $this->assertTrue($robots->allows('/fr/admin?'));
         $this->assertTrue($robots->allows('/fr/admin?test'));
     }
 

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -81,8 +81,6 @@ class RobotsTxtTest extends TestCase
     /** @test */
     public function it_can_handle_star_in_pattern()
     {
-        $this->markAsSkippedUnlessLocalTestServerIsRunning();
-
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertTrue($robots->allows('/en/admin'));
@@ -93,8 +91,6 @@ class RobotsTxtTest extends TestCase
     /** @test */
     public function it_can_handle_dollar_in_pattern()
     {
-        $this->markAsSkippedUnlessLocalTestServerIsRunning();
-
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertTrue($robots->allows('/fr/ad'));
@@ -106,8 +102,6 @@ class RobotsTxtTest extends TestCase
     /** @test */
     public function it_can_handle_query_strings()
     {
-        $this->markAsSkippedUnlessLocalTestServerIsRunning();
-
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertTrue($robots->allows('/en/admin'));

--- a/tests/data/robots.txt
+++ b/tests/data/robots.txt
@@ -2,8 +2,9 @@
 
 User-agent: *
 
+Disallow: /*?
 Disallow: /nl/admin/
-Disallow: /en/admin/
+Disallow: /en/admin/*
 Disallow: /es/admin-disallow/
 User-agent: google
 

--- a/tests/data/robots.txt
+++ b/tests/data/robots.txt
@@ -2,9 +2,10 @@
 
 User-agent: *
 
-Disallow: /*?
+Disallow: /*?print
 Disallow: /nl/admin/
 Disallow: /en/admin/*
+Disallow: /fr/admin$
 Disallow: /es/admin-disallow/
 User-agent: google
 

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -49,6 +49,14 @@ app.get('/nl', function (req, res) {
     res.end();
 });
 
+app.get('/nl/admin', function (req, res) {
+    console.log('Request at /nl/admin');
+
+    res.writeHead(200);
+
+    res.end();
+});
+
 var server = app.listen(4020, function () {
     var host = 'localhost';
     var port = server.address().port;


### PR DESCRIPTION
This library does not currently handle a few important parts of the robots.txt protocol:

- the patterns should match against the entire request URI (path + query string); it currently only matches the path
- the `*` wildcard is not implemented
- the `$` end-of-string is not implemented

Reference: https://developers.google.com/search/reference/robots_txt

Also, there is a bug in how trailing slashes are handled. The current library expects:

```
Disallow: /nl/admin/
```

...to disallow `/nl/admin` as well. There was code [specifically crafted for this purpose](https://github.com/spatie/robots-txt/blob/351c96d4431d751872372684253b310d7f15210e/src/RobotsTxt.php#L47), although it is plain wrong AFAIK, which I confirmed using these online testers: [1](https://technicalseo.com/tools/robots-txt/), [2](http://tools.seobook.com/robots-txt/analyzer/).

**This PR adds support for the above, and fixes the bug.**