### PR TITLE
Prevent parsing of large HTML blobs to reach out-of-memory exceptions

### DIFF
--- a/src/RobotsMeta.php
+++ b/src/RobotsMeta.php
@@ -10,7 +10,7 @@ class RobotsMeta
 
     public static function readFrom(string $source): self
     {
-        $content = @file_get_contents($source);
+        $content = @file_get_contents($source, false, NULL, 0, 1 * 1024 * 1024);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read from source `{$source}`");

--- a/src/RobotsMeta.php
+++ b/src/RobotsMeta.php
@@ -10,7 +10,7 @@ class RobotsMeta
 
     public static function readFrom(string $source): self
     {
-        $content = @file_get_contents($source, false, NULL, 0, 1 * 1024 * 1024);
+        $content = @file_get_contents($source);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read from source `{$source}`");
@@ -21,6 +21,8 @@ class RobotsMeta
 
     public static function create(string $source): self
     {
+        $source = substr($source, 0, 1 * 1024 * 1024);
+
         return new self($source);
     }
 


### PR DESCRIPTION
This is a pragmatic approach to issue #19 

The `RobotsMeta` class looks at the HTML source code to find HTML meta tags. This PR assumes that the `<head>` is contained within the very first 1,048,576 characters (`1024 * 1024`) of `$html` which seems like a reasonable bet.

A typical homepage will have the `head` section within the first 10,000 characters, the `1024 * 1024` rule gives plenty of headroom without causing out of memory exceptions.