### PR TITLE
fix headers checking (nofollow, noindex) for custom userAgent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+tests/server/package-lock.json

--- a/src/RobotsHeaders.php
+++ b/src/RobotsHeaders.php
@@ -42,11 +42,8 @@ class RobotsHeaders
     public function noindex(string $userAgent = '*'): bool
     {
         return
-            // 1. We check for the suggested user-agent
             $this->robotHeadersProperties[$userAgent]['noindex']
-            // 2. We check for all user-agent
             ?? $this->robotHeadersProperties['*']['noindex']
-            // 3. noindex doesn't exist, so return fasle
             ?? false;
     }
 

--- a/src/RobotsHeaders.php
+++ b/src/RobotsHeaders.php
@@ -41,12 +41,21 @@ class RobotsHeaders
 
     public function noindex(string $userAgent = '*'): bool
     {
-        return $this->robotHeadersProperties[$userAgent]['noindex'] ?? false;
+        return
+            // 1. We check for the suggested user-agent
+            $this->robotHeadersProperties[$userAgent]['noindex']
+            // 2. We check for all user-agent
+            ?? $this->robotHeadersProperties['*']['noindex']
+            // 3. noindex doesn't exist, so return fasle
+            ?? false;
     }
 
     public function nofollow(string $userAgent = '*'): bool
     {
-        return $this->robotHeadersProperties[$userAgent]['nofollow'] ?? false;
+        return
+            $this->robotHeadersProperties[$userAgent]['nofollow']
+            ?? $this->robotHeadersProperties['*']['nofollow']
+            ?? false;
     }
 
     protected function parseHeaders(array $headers): array

--- a/tests/RobotsHeadersTest.php
+++ b/tests/RobotsHeadersTest.php
@@ -20,6 +20,8 @@ class RobotsHeadersTest extends TestCase
 
         $this->assertFalse($robots->mayIndex('google'));
         $this->assertFalse($robots->mayFollow('google'));
+
+        $this->assertFalse($robots->mayFollow('other-bot'));
     }
 
     /** @test */
@@ -48,6 +50,11 @@ class RobotsHeadersTest extends TestCase
         $this->markAsSkippedUnlessLocalTestServerIsRunning();
 
         $robots = RobotsHeaders::readFrom($this->getLocalTestServerUrl('/nofollow-noindex-google'));
+
+        $this->assertFalse($robots->mayIndex('google'));
+        $this->assertFalse($robots->mayFollow('google'));
+
+        $robots = RobotsHeaders::readFrom($this->getLocalTestServerUrl('/nofollow-noindex'));
 
         $this->assertFalse($robots->mayIndex('google'));
         $this->assertFalse($robots->mayFollow('google'));


### PR DESCRIPTION
When we check for a custom userAgent, is it the expected behavior to return mayIndex() or mayFollow() to true if there is an arguments for all robots ?

I hope I was clear, else I updated the tests wich are clearest than me now.