### PR TITLE
user agent is converted to lowercase for matching

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -50,7 +50,7 @@ class RobotsTxt
             }
         }
 
-        $disallows = $this->disallowsPerUserAgent[$userAgent] ?? $this->disallowsPerUserAgent['*'] ?? [];
+        $disallows = $this->disallowsPerUserAgent[strtolower(trim($userAgent))] ?? $this->disallowsPerUserAgent['*'] ?? [];
 
         return ! $this->pathIsDenied($requestUri, $disallows);
     }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -117,6 +117,7 @@ class RobotsTxtTest extends TestCase
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertTrue($robots->allows('/', 'UserAgent007'));
+        $this->assertTrue($robots->allows('/', strtolower('UserAgent007')));
     }
 
     /** @test */
@@ -125,5 +126,6 @@ class RobotsTxtTest extends TestCase
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
         $this->assertFalse($robots->allows('/no-agents', 'UserAgent007'));
+        $this->assertFalse($robots->allows('/no-agents', strtolower('UserAgent007')));
     }
 }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -110,4 +110,20 @@ class RobotsTxtTest extends TestCase
         $this->assertFalse($robots->allows('/en/admin?print'));
         $this->assertFalse($robots->allows('/en/admin?print=true'));
     }
+
+    /** @test */
+    public function test_allowed_link_for_title_case_custom_user_agent()
+    {
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertTrue($robots->allows('/', 'UserAgent007'));
+    }
+
+    /** @test */
+    public function test_disallowed_link_for_title_case_custom_user_agent()
+    {
+        $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
+
+        $this->assertFalse($robots->allows('/no-agents', 'UserAgent007'));
+    }
 }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -112,7 +112,7 @@ class RobotsTxtTest extends TestCase
     }
 
     /** @test */
-    public function test_allowed_link_for_title_case_custom_user_agent()
+    public function the_allows_user_agent_check_is_case_insensitive()
     {
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 
@@ -121,7 +121,7 @@ class RobotsTxtTest extends TestCase
     }
 
     /** @test */
-    public function test_disallowed_link_for_title_case_custom_user_agent()
+    public function the_disallows_user_agent_check_is_case_insensitive()
     {
         $robots = RobotsTxt::readFrom(__DIR__.'/data/robots.txt');
 

--- a/tests/data/robots.txt
+++ b/tests/data/robots.txt
@@ -10,3 +10,6 @@ Disallow: /es/admin-disallow/
 User-agent: google
 
 Disallow: /
+User-agent: UserAgent007
+
+Disallow: /no-agents


### PR DESCRIPTION
#25 

$userAgent variable is now converted to lowercase to be found in $disallowsPerUserAgent array.

_This is my first contribution to a public repo. I apologize if I did something missing/wrong._