### PR TITLE
Fix deprecation message

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -50,7 +50,7 @@ class RobotsTxt
             }
         }
 
-        $disallows = $this->disallowsPerUserAgent[strtolower(trim($userAgent))] ?? $this->disallowsPerUserAgent['*'] ?? [];
+        $disallows = $this->disallowsPerUserAgent[strtolower(trim($userAgent ?? ''))] ?? $this->disallowsPerUserAgent['*'] ?? [];
 
         return ! $this->pathIsDenied($requestUri, $disallows);
     }


### PR DESCRIPTION
`PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in .../php-crawler/vendor/spatie/robots-txt/src/RobotsTxt.php on line 53`