### PR TITLE
Add some efficiencies to prevent unnecessary requests

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -39,17 +39,29 @@ class Robots
 
         $robotsTxt = $this->robotsTxt ?? RobotsTxt::create($this->createRobotsUrl($url));
 
+        $content = @file_get_contents($url);
+
+        if ($content === false) {
+            throw new InvalidArgumentException("Could not read url `{$url}`");
+        }
+
         return
             $robotsTxt->allows($url, $userAgent)
-            && RobotsMeta::readFrom($url)->mayIndex()
-            && RobotsHeaders::readFrom($url)->mayIndex();
+            && RobotsMeta::create($content)->mayIndex()
+            && RobotsHeaders::create($http_response_header ?? [])->mayIndex();
     }
 
     public function mayFollowOn(string $url): bool
     {
+        $content = @file_get_contents($url);
+
+        if ($content === false) {
+            throw new InvalidArgumentException("Could not read url `{$url}`");
+        }
+
         return
-            RobotsMeta::readFrom($url)->mayFollow()
-            && RobotsHeaders::readFrom($url)->mayFollow();
+            RobotsMeta::create($content)->mayFollow()
+            && RobotsHeaders::create($http_response_header ?? [])->mayFollow();
     }
 
     protected function createRobotsUrl(string $url): string

--- a/src/Robots.php
+++ b/src/Robots.php
@@ -19,9 +19,11 @@ class Robots
         }
     }
 
-    public function withTxt(string $source): self
+    public function withTxt(RobotsTxt | string $source): self
     {
-        $this->robotsTxt = RobotsTxt::readFrom($source);
+        $this->robotsTxt = $source instanceof RobotsTxt
+                                ? $source
+                                : RobotsTxt::readFrom($source);
 
         return $this;
     }

--- a/src/Robots.php
+++ b/src/Robots.php
@@ -8,11 +8,15 @@ class Robots
 
     public function __construct(
         protected string | null $userAgent = null,
-        string | null $source = null,
+        RobotsTxt | string | null $source = null,
     ) {
-        $this->robotsTxt = $source
-            ? RobotsTxt::readFrom($source)
-            : null;
+        if ($source instanceof RobotsTxt) {
+            $this->robotsTxt = $source;
+        } elseif (is_string($source)) {
+            $this->robotsTxt = RobotsTxt::readFrom($source);
+        } else {
+            $this->robotsTxt = null;
+        }
     }
 
     public function withTxt(string $source): self

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Robots\Tests;
 
 use Spatie\Robots\Robots;
+use Spatie\Robots\RobotsTxt;
 
 class RobotsTest extends TestCase
 {
@@ -11,6 +12,16 @@ class RobotsTest extends TestCase
     {
         $robots = Robots::create()
             ->withTxt(__DIR__.'/data/robots.txt');
+
+        $this->assertTrue($robots->mayIndex('/'));
+    }
+
+    /** @test */
+    public function it_can_be_created_with_a_robots_txt_object()
+    {
+        $robotsTxt = RobotsTxt::create(__DIR__.'/data/robots.txt');
+        $robots = Robots::create()
+            ->withTxt($robotsTxt);
 
         $this->assertTrue($robots->mayIndex('/'));
     }


### PR DESCRIPTION
There are two changes in this PR that will help me use the package more efficiently.

1) Be able to provider Robots with a RobotsTxt object directly. I have access to the robots.txt file in memory and don't want to write it to disk first. With this change, I can create a RobotsTxt object from the string in memory and create a Robot with it.

2) Calling `mayIndex()` and `mayFollowOn()` on a Robot class causes two requests to the remote server. This change pulls the `file_get_contents()` request up one level and prevents `RobotsMeta` and `RobotsHeader` from each having to do their own requests.