### PR TITLE
Add missing use statement for InvalidArgumentException

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Robots;
 
+use InvalidArgumentException;
+
 class Robots
 {
     protected RobotsTxt | null $robotsTxt;


### PR DESCRIPTION
Add missing use statement for InvalidArgumentException that is causing `Class "Spatie\Robots\InvalidArgumentException" not found` exceptions when thrown