### PR TITLE
avoid expensive queries that do not change certain results

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -41,15 +41,17 @@ class Robots
 
         $robotsTxt = $this->robotsTxt ?? RobotsTxt::create($this->createRobotsUrl($url));
 
+        if (! $robotsTxt->allows($url, $userAgent)) {
+            return false;
+        }
+
         $content = @file_get_contents($url);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");
         }
 
-        return
-            $robotsTxt->allows($url, $userAgent)
-            && RobotsMeta::create($content)->mayIndex()
+        return RobotsMeta::create($content)->mayIndex()
             && RobotsHeaders::create($http_response_header ?? [])->mayIndex();
     }
 


### PR DESCRIPTION
The (mayIndex)[https://github.com/spatie/robots-txt/blob/053c9dfdddb16d351f69de74d9e1a94c8dfd0b3e/src/Robots.php#L38] function, which checks whether a page can be indexed or not, is downloading the website content even if the **robots.txt** was already cached and disallowing that page.

With this PR no result is changed but in case the **robots.txt** denies a page, it won't even be fetched (as reading the page meta wouldn't change that result).

The results of the tests is exactly the same after this change, only that some unnecessary calls to (the expensive) **file_get_contents** are avoided.