### PR TITLE
RobotsTxt: add missing class property - allowsPerUserAgent

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -7,6 +7,7 @@ class RobotsTxt
     protected static array $robotsCache = [];
 
     protected array $disallowsPerUserAgent = [];
+    protected array $allowsPerUserAgent = [];
 
     protected bool $matchExactly = true;
 


### PR DESCRIPTION
 to stop dynamic property warning,

see https://github.com/spatie/robots-txt/pull/60#discussion_r1930684803
see https://github.com/spatie/robots-txt/pull/60