### PR TITLE
Implement RobotsTxt->whyDisallows($path, $userAgent) to find why a path was disallowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ $robots = Spatie\Robots\Robots::create();
 $robots->mayIndex('https://www.spatie.be/nl/admin');
 
 $robots->mayFollowOn('https://www.spatie.be/nl/admin');
+
+$robotsTxt = new RobotsTxt('
+  User-agent: *
+  Disallow: /admin
+  Crawl-delay: 1.5
+');
+$robotsTxt->allows('/admin', 'google'); // false
+$robotsTxt->whyDisallows('/admin', 'google')[0]->userAgent; // '*'
+$robotsTxt->crawlDelay('/admin', '*'); // '1.5'
 ```
 
 You can also specify a user agent:

--- a/src/Disallow.php
+++ b/src/Disallow.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Robots;
+
+/**
+ * A specific Disallow entry in a robots.txt
+ */
+class Disallow
+{
+
+    public function __construct(
+        public readonly string $userAgent,
+        public readonly string $basePath
+    ) {
+
+    }
+
+}

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -124,6 +124,34 @@ class RobotsTxt
         return ! $isDenied;
     }
 
+    /**
+     * @return Disallow[]|null Null if path is allowed, or a list of reasons if path is disallowed
+     */
+    public function whyDisallows(string $path, string $userAgent): ?array {
+        if ($this->allows($path, $userAgent)) {
+            return null;
+        }
+        $reasons = $this->getDisallows($path, $userAgent);
+        if ($userAgent !== '*') {
+            $newDisallows = $this->getDisallows($path, '*');
+            $reasons = array_merge($reasons, $newDisallows);
+        }
+        return $reasons;
+    }
+
+    /**
+     * @return Disallow[]
+     */
+    protected function getDisallows(string $path, string $userAgent): array {
+        $reasons = [];
+        foreach ($this->disallowsPerUserAgent[$userAgent] as $disallowedPath => $length) {
+            if (str_starts_with($path, $disallowedPath)) {
+                $reasons[] = new Disallow($userAgent, $disallowedPath);
+            }
+        }
+        return $reasons;
+    }
+
     public function crawlDelay(string $userAgent = '*'): ?string
     {
         $crawlDelaysPerUserAgent = $this->includeGlobalGroup

--- a/src/WhyDisallows.php
+++ b/src/WhyDisallows.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Robots;
+
+class WhyDisallows
+{
+
+    /**
+     * @param Disallow[] $reasons
+     */
+    public function __construct(public readonly array $reasons) {
+
+    }
+
+}

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -413,4 +413,32 @@ class RobotsTxtTest extends TestCase
         $this->assertEquals('/hello', $reasons[0]->basePath);
     }
 
+    /** @test */
+    public function it_can_find_multiple_disallow_reasons_per_user_agent() {
+        $robots = new RobotsTxt(
+            '
+            User-agent: *
+            Disallow: /hello
+            Disallow: /hello-world
+            Disallow: /goodbye
+            
+            User-agent: google
+            Disallow: /hello
+            Disallow: /hello-world
+            Disallow: /hello-kitty
+        '
+        );
+        $reasons = $robots->whyDisallows('/hello-world', 'google');
+        $this->assertNotNull($reasons);
+        $this->assertCount(4, $reasons);
+        $this->assertEquals('google', $reasons[0]->userAgent);
+        $this->assertEquals('/hello', $reasons[0]->basePath);
+        $this->assertEquals('google', $reasons[1]->userAgent);
+        $this->assertEquals('/hello-world', $reasons[1]->basePath);
+        $this->assertEquals('*', $reasons[2]->userAgent);
+        $this->assertEquals('/hello', $reasons[2]->basePath);
+        $this->assertEquals('*', $reasons[3]->userAgent);
+        $this->assertEquals('/hello-world', $reasons[3]->basePath);
+    }
+
 }


### PR DESCRIPTION
 ```php
$robots = new RobotsTxt('
    User-agent: *
    Disallow: /hello
            
    User-agent: google
    Disallow: /hello
            
    User-agent: bing
    Disallow: /hello-world
');
$reasons = $robots->whyDisallows('/hello-world', 'google');
$this->assertNotNull($reasons);
$this->assertCount(2, $reasons);
$this->assertEquals('google', $reasons[0]->userAgent);
$this->assertEquals('/hello', $reasons[0]->basePath);
$this->assertEquals('*', $reasons[1]->userAgent);
$this->assertEquals('/hello', $reasons[1]->basePath);
```