### PR TITLE
Added stream context options to all calls that use file_get_contents

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -35,7 +35,10 @@ class Robots
         return new self($userAgent, $source);
     }
 
-    public function mayIndex(string $url, ?string $userAgent = null): bool
+    /**
+     * @param resource|null $context
+     */
+    public function mayIndex(string $url, ?string $userAgent = null, $context = null): bool
     {
         $userAgent = $userAgent ?? $this->userAgent;
 
@@ -45,7 +48,7 @@ class Robots
             return false;
         }
 
-        $content = @file_get_contents($url);
+        $content = @file_get_contents($url, context: is_resource($context) ? $context : null);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");
@@ -55,9 +58,12 @@ class Robots
             && RobotsHeaders::create($http_response_header ?? [])->mayIndex();
     }
 
-    public function mayFollowOn(string $url): bool
+    /**
+     * @param resource|null $context
+     */
+    public function mayFollowOn(string $url, $context = null): bool
     {
-        $content = @file_get_contents($url);
+        $content = @file_get_contents($url, context: is_resource($context) ? $context : null);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");

--- a/src/RobotsHeaders.php
+++ b/src/RobotsHeaders.php
@@ -8,9 +8,12 @@ class RobotsHeaders
 {
     protected array $robotHeadersProperties = [];
 
-    public static function readFrom(string $source): self
+    /**
+     * @param resource|null $context
+     */
+    public static function readFrom(string $source, $context = null): self
     {
-        $content = @file_get_contents($source);
+        $content = @file_get_contents($source, context: is_resource($context) ? $context : null);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read from source `{$source}`");

--- a/src/RobotsMeta.php
+++ b/src/RobotsMeta.php
@@ -9,9 +9,12 @@ class RobotsMeta
 {
     protected array $robotsMetaTagProperties = [];
 
-    public static function readFrom(string $source): self
+    /**
+     * @param resource|null $context
+     */
+    public static function readFrom(string $source, $context = null): self
     {
-        $content = @file_get_contents($source);
+        $content = @file_get_contents($source, context: is_resource($context) ? $context : null);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read from source `{$source}`");

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -4,8 +4,6 @@ namespace Spatie\Robots;
 
 class RobotsTxt
 {
-    protected static array $robotsCache = [];
-
     protected array $disallowsPerUserAgent = [];
 
     protected array $allowsPerUserAgent = [];
@@ -44,9 +42,12 @@ class RobotsTxt
         return $this;
     }
 
-    public static function readFrom(string $source): self
+    /**
+     * @param resource|null $context
+     */
+    public static function readFrom(string $source, $context = null): self
     {
-        $content = @file_get_contents($source);
+        $content = @file_get_contents($source, context: is_resource($context) ? $context : null);
 
         return new self($content !== false ? $content : '');
     }

--- a/tests/RobotsHeadersTest.php
+++ b/tests/RobotsHeadersTest.php
@@ -107,4 +107,30 @@ class RobotsHeadersTest extends TestCase
         $this->assertTrue($robots->mayIndex());
         $this->assertTrue($robots->mayFollow());
     }
+
+    /** @test */
+    public function it_can_use_stream_context()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        // Execute a valid call, not expecting an exception
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'test-user-agent',
+            ]
+        ]);
+
+        RobotsHeaders::readFrom($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+
+        // Execute an invalid call, expecting it to fail, confirming the expected result
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'bad-user-agent',
+            ]
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        RobotsHeaders::readFrom($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+    }
 }

--- a/tests/RobotsMetaTest.php
+++ b/tests/RobotsMetaTest.php
@@ -46,4 +46,30 @@ class RobotsMetaTest extends TestCase
 
         $this->assertTrue(RobotsMeta::readFrom(__DIR__.'/data/all-allowed.html')->mayFollow());
     }
+
+    /** @test */
+    public function it_can_use_stream_context()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        // Execute a valid call, not expecting an exception
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'test-user-agent',
+            ]
+        ]);
+
+        RobotsMeta::readFrom($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+
+        // Execute an invalid call, expecting it to fail, confirming the expected result
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'bad-user-agent',
+            ]
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        RobotsMeta::readFrom($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+    }
 }

--- a/tests/RobotsTest.php
+++ b/tests/RobotsTest.php
@@ -72,4 +72,60 @@ class RobotsTest extends TestCase
 
         $this->assertTrue($robots->mayIndex($this->getLocalTestServerUrl('/nl')));
     }
+
+    /** @test */
+    public function may_index_can_use_stream_context()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        $robots = Robots::create();
+
+        // Execute a valid call, not expecting an exception
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'test-user-agent',
+            ]
+        ]);
+
+        $robots->mayIndex($this->getLocalTestServerUrl('/client-ua-must-match'), null, $context);
+
+        // Execute an invalid call, expecting it to fail, confirming the expected result
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'bad-user-agent',
+            ]
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $robots->mayIndex($this->getLocalTestServerUrl('/client-ua-must-match'), null, $context);
+    }
+
+    /** @test */
+    public function may_follow_on_can_use_stream_context()
+    {
+        $this->markAsSkippedUnlessLocalTestServerIsRunning();
+
+        $robots = Robots::create();
+
+        // Execute a valid call, not expecting an exception
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'test-user-agent',
+            ]
+        ]);
+
+        $robots->mayFollowOn($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+
+        // Execute an invalid call, expecting it to fail, confirming the expected result
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'bad-user-agent',
+            ]
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $robots->mayFollowOn($this->getLocalTestServerUrl('/client-ua-must-match'), $context);
+    }
 }

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -73,6 +73,12 @@ app.get('/nl/admin', function (req, res) {
     res.end();
 });
 
+app.get('/client-ua-must-match', function (req, res) {
+    const userAgent = req.headers['user-agent'];
+
+    return res.status(userAgent === 'test-user-agent' ? 200 : 400).end()
+});
+
 var server = app.listen(4020, function () {
     var host = 'localhost';
     var port = server.address().port;


### PR DESCRIPTION
Added stream context options to all methods that rely on file_get_contents.

Reasoning:
- Can't identify itself correctly to the host during the crawl, except through [user_agent php.ini setting](https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent).
- Can't specify any additional options, like allow self signed certificates and other relevant things.

Tests do a simple check if the correct user-agent is used during the query (200 response if it does, 400 if not, failing the query). Except for `\Spatie\Robots\RobotsTxt::readFrom` which does not fail on stream errors like all the other methods so I have no clue how I could even hook into that for tests, so no tests for that one.

Also removed an unused `static array $robotsCache`.
