### PR TITLE
fix: fix warnings and avoid unused variables

### DIFF
--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -147,7 +147,7 @@ class RobotsTxt
     protected function getDisallows(string $path, string $userAgent): array
     {
         $reasons = [];
-        foreach ($this->disallowsPerUserAgent[$userAgent] as $disallowedPath => $length) {
+        foreach (array_keys($this->disallowsPerUserAgent[$userAgent] ?? []) as $disallowedPath) {
             if (str_starts_with($path, $disallowedPath)) {
                 $reasons[] = new Disallow($userAgent, $disallowedPath);
             }
@@ -213,7 +213,7 @@ class RobotsTxt
 
     protected function pathIsDenied(string $requestUri, array $disallows): bool
     {
-        foreach ($disallows as $disallow => $value) {
+        foreach (array_keys($disallows) as $disallow) {
             if ($disallow === '') {
                 continue;
             }


### PR DESCRIPTION
When running the tests, some PHP warnings are triggered:

1) /tmp/php/spatie/robots-txt/src/RobotsTxt.php:150
Undefined array key "google"

Triggered by:

* Spatie\Robots\Tests\RobotsTxtTest::it_can_tell_why_path_is_disallowed_for_user_agent
  /tmp/php/spatie/robots-txt/tests/RobotsTxtTest.php:328

2) /tmp/php/spatie/robots-txt/src/RobotsTxt.php:150
foreach() argument must be of type array|object, null given

Triggered by:

* Spatie\Robots\Tests\RobotsTxtTest::it_can_tell_why_path_is_disallowed_for_user_agent
  /tmp/php/spatie/robots-txt/tests/RobotsTxtTest.php:328

This MR fixes those warnings and also avoids unused variables.