### PR TITLE
fix(#75) : fix an issue that subsequence file_get_contents calls can cause 429 status error

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -45,7 +45,7 @@ class Robots
             return false;
         }
 
-        $content = @file_get_contents($url);
+        $content = $robotsTxt->content;
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -51,7 +51,7 @@ class RobotsTxt
         return new self($content !== false ? $content : '');
     }
 
-    public function __construct(string $content)
+    public function __construct(public readonly string $content)
     {
         $this->disallowsPerUserAgent = $this->getDisallowsPerUserAgent($content);
         $this->allowsPerUserAgent = $this->getAllowsPerUserAgent($content);

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -51,7 +51,7 @@ class RobotsTxt
         return new self($content !== false ? $content : '');
     }
 
-    public function __construct(public readonly string $content)
+    public function __construct(public string $content)
     {
         $this->disallowsPerUserAgent = $this->getDisallowsPerUserAgent($content);
         $this->allowsPerUserAgent = $this->getAllowsPerUserAgent($content);


### PR DESCRIPTION
In certain sites the package fails to return the correct response when using `$robots->mayIndex()` vs `$robotsTxt->allows()`, because the both method calls `file_get_contents` in quick succession, which can cause throttling.

Since `$robotsTxt->allows()` already loads the content of the `robots.txt`, I wonder if we could simply use the returned content in `$robots->mayIndex()` instead of attempt to load again.