### PR TITLE
Send user agent header with file_get_contents requests

### DIFF
--- a/src/Robots.php
+++ b/src/Robots.php
@@ -45,7 +45,9 @@ class Robots
             return false;
         }
 
-        $content = @file_get_contents($url);
+        $context = $this->createStreamContext();
+
+        $content = @file_get_contents($url, false, $context);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");
@@ -57,7 +59,9 @@ class Robots
 
     public function mayFollowOn(string $url): bool
     {
-        $content = @file_get_contents($url);
+        $context = $this->createStreamContext();
+
+        $content = @file_get_contents($url, false, $context);
 
         if ($content === false) {
             throw new InvalidArgumentException("Could not read url `{$url}`");
@@ -66,6 +70,15 @@ class Robots
         return
             RobotsMeta::create($content)->mayFollow()
             && RobotsHeaders::create($http_response_header ?? [])->mayFollow();
+    }
+
+    protected function createStreamContext()
+    {
+        return stream_context_create([
+            'http' => [
+                'user_agent' => $this->userAgent ?? 'spatie/robots-txt',
+            ],
+        ]);
     }
 
     protected function createRobotsUrl(string $url): string

--- a/src/RobotsTxt.php
+++ b/src/RobotsTxt.php
@@ -46,7 +46,13 @@ class RobotsTxt
 
     public static function readFrom(string $source): self
     {
-        $content = @file_get_contents($source);
+        $context = stream_context_create([
+            'http' => [
+                'user_agent' => 'spatie/robots-txt',
+            ],
+        ]);
+
+        $content = @file_get_contents($source, false, $context);
 
         return new self($content !== false ? $content : '');
     }


### PR DESCRIPTION
## Summary
- Sends a `User-Agent` header with all `file_get_contents` HTTP requests
- Cloudflare and similar WAFs block requests without a `User-Agent` header, causing `mayIndex()` and `mayFollowOn()` to fail
- Uses the configured `$userAgent` when available, falls back to `spatie/robots-txt`
- Also applies to `RobotsTxt::readFrom()` which fetches the robots.txt file itself

Fixes #83